### PR TITLE
Updated Luhn algorithm, and fix issue #2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,9 @@
   "authors": [
     "Fredrik Forsmo <fredrik.forsmo@gmail.com>"
   ],
+  "contributors": [
+    "Mattias Hagberg <hello@mattias.pw> (https://www.mattias.pw)"
+  ],
   "moduleType": [
     "amd",
     "globals",

--- a/cli.js
+++ b/cli.js
@@ -1,24 +1,31 @@
 #!/usr/bin/env node
 
-var pnr  = require('./');
+var pnr = require('./');
 var meow = require('meow');
-var cli  = meow({
-	help: [
-		'Usage',
-		'  $ is-personnummer-cli [input]',
-		'',
-		'Examples',
-		'  $ is-personnummer-cli 510818-9167',
-		'  true',
-		'',
-		'  $ is-personnummer-cli 19130401+293',
-		'  false',
-		''
-	]
+var cli = meow({
+    help: [
+        'Usage',
+        '  $ is-personnummer-cli [input]',
+        '',
+        'Examples',
+        '  $ is-personnummer-cli 510818-9167',
+        '  true',
+        '',
+        '  $ is-personnummer-cli 19130401+293',
+        '  false',
+        ''
+    ]
 });
 
 if (!cli.input[0]) {
-  console.log(cli.help);
+    console.log(cli.help);
 } else {
-  console.log(pnr(cli.input[0]));
+    var ret = cli.input[0];
+    var l = ret.toString().length;
+    if(pnr(ret) === false){
+        // might be leading zeros
+        if(l <= 7) {
+            console.log(pnr('000' + ret));
+        }
+    } else console.log(pnr(ret));
 }

--- a/is-personnummer.js
+++ b/is-personnummer.js
@@ -1,116 +1,106 @@
 /**
- * is-personnummer
- * https://github.com/frozzare/is-personnummer
- *
- * Copyright (c) 2014 Fredrik Forsmo
- * Licensed under the MIT license.
- */
+* is-personnummer
+* https://github.com/frozzare/is-personnummer
+*
+* Copyright (c) 2014 Fredrik Forsmo
+* Licensed under the MIT license.
+*/
 
 'use strict';
 
 /**
- * Export the module for AMD, Browser and Node.
- */
+* Export the module for AMD, Browser and Node.
+*/
 
 (function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define([], factory);
-  } else if (typeof module !== 'undefined' && module.exports) {
-    module.exports = factory();
-  } else {
-    root.isPersonnummer = factory();
-  }
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module !== 'undefined' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.isPersonnummer = factory();
+    }
 }(this, function () {
+    /**
+    * The Luhn algorithm.
+    *
+    * @param {string|number} str
+    *
+    * @return {number}
+    */
 
-  /**
-   * The Luhn algorithm.
-   *
-   * @param {string|number} str
-   *
-   * @return {number}
-   */
+    function luhn(str) {
+        var d = 0,
+            e = false; // e = even = n-th digit counted from the end
 
-  function luhn (str) {
-    var v   = 0;
-    var sum = 0;
-
-    str += '';
-
-    for (var i = 0, l = str.length; i < l; i++) {
-      v = str[i];
-      v *= 2 - (i % 2);
-      if (v > 9) {
-        v -= 9;
-      }
-      sum += v;
+        return (str.split('').reverse().reduce(
+            function(s, dstr){
+                d = parseInt(dstr); // reduce arg 0 - callback function
+                return (s + ((e = !e) ? d : [0, 2, 4, 6, 8, 1, 3, 5, 7, 9][d]));
+            }, 0 // reduce arg 1 - prev value for first iteration (sum)
+        ) % 10 == 0);
     }
 
-    return Math.ceil(sum / 10) * 10 - sum;
-  }
+    /**
+    * Test date if lunh is true.
+    *
+    * @param {int} year
+    * @param {int} month
+    * @param {int} day
+    *
+    * @return {boolean}
+    */
 
-
-  /**
-   * Test date if lunh is true.
-   *
-   * @param {int} year
-   * @param {int} month
-   * @param {int} day
-   *
-   * @return {boolean}
-   */
-
-  function testDate (year, month, day) {
-    month -= 1;
-    var date = new Date(year, month, day);
-    return !(date.getYear() !== year || date.getMonth() !== month || date.getDate() !== day);
-  }
-
-
-  /**
-   * Validate Swedish personal identity numbers.
-   *
-   * @param {string|number} str
-   *
-   * @return {boolean}
-   */
-
-  return function (str) {
-    if (typeof str !== 'number' && typeof str !== 'string') {
-      return false;
+    function testDate (year, month, day) {
+        month -= 1;
+        var date = new Date(year, month, day);
+        return !(date.getYear() !== year || date.getMonth() !== month || date.getDate() !== day);
     }
 
-    str += '';
 
-    var reg     = /^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\-|\+]{0,1})?(\d{3})(\d{0,1})$/;
-    var match   = reg.exec(str);
+    /**
+    * Validate Swedish personal identity numbers.
+    *
+    * @param {string|number} str
+    *
+    * @return {boolean}
+    */
 
-    if (!match) {
-      return false;
-    }
+    return function (str) {
+        if (typeof str !== 'number' && typeof str !== 'string') {
+            return false;
+        }
 
-    var century = match[1];
-    var year    = match[2];
-    var month   = match[3];
-    var day     = match[4];
-    var sep     = match[5];
-    var num     = match[6];
-    var check   = match[7];
+        str += '';
 
-    if (sep === undefined) {
-      sep = '-';
-    }
+        var reg = /^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\-|\+]{0,1})?(\d{3})(\d{0,1})$/;
+        var match = reg.exec(str);
 
-    if (year.length === 4) {
-      year = year.substr(2)
-    }
+        if (!match) {
+            return false;
+        }
 
-    var valid = luhn(year + month + day + num) === +check && !!check;
+        var year = match[2];
+        var month = match[3];
+        var day = match[4];
+        var sep = match[5];
+        var num = match[6];
+        var check = match[7];
 
-    if (valid && testDate(+year, +month, +day)) {
-      return valid;
-    }
+        if (sep === undefined) {
+            sep = '-';
+        }
 
-    return valid && testDate(+year, +month, +day - 60);
-  }
+        if (year.length === 4) {
+            year = year.substr(2);
+        }
 
+        var valid = luhn(year + month + day + num + check);
+
+        if (valid && testDate(+year, +month, +day)) {
+            return valid;
+        }
+
+        return valid && testDate(+year, +month, +day - 60);
+    };
 }));

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "email": "fredrik.forsmo@gmail.com",
     "url": "http://forsmo.me"
   },
+  "contributors": [
+    "Mattias Hagberg <hello@mattias.pw> (https://www.mattias.pw)"
+  ],
   "bin": "cli.js",
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,51 +1,55 @@
-var assert         = require('assert');
+var assert = require('assert');
 var isPersonnummer = require('./is-personnummer');
 
 it('should validate personnummer with control digit', function () {
-  assert.equal(true, isPersonnummer(6403273813));
-  assert.equal(true, isPersonnummer('510818-9167'));
-  assert.equal(true, isPersonnummer('19900101-0017'));
-  assert.equal(true, isPersonnummer('19130401+2931'));
-  assert.equal(true, isPersonnummer('196408233234'));
+    assert.equal(true, isPersonnummer(6403273813));
+    assert.equal(true, isPersonnummer('510818-9167'));
+    assert.equal(true, isPersonnummer('19900101-0017'));
+    assert.equal(true, isPersonnummer('19130401+2931'));
+    assert.equal(true, isPersonnummer('196408233234'));
+    assert.equal(true, isPersonnummer('20000101-0107'));
+    assert.equal(true, isPersonnummer('200001010107'));
+    assert.equal(true, isPersonnummer('000101-0107'));
+    assert.equal(true, isPersonnummer('0001010107'));
 });
 
 it('should not validate personnummer without control digit', function () {
-  assert.equal(false, isPersonnummer(640327381));
-  assert.equal(false, isPersonnummer('510818-916'));
-  assert.equal(false, isPersonnummer('19900101-001'));
-  assert.equal(false, isPersonnummer('100101+001'));
+    assert.equal(false, isPersonnummer(640327381));
+    assert.equal(false, isPersonnummer('510818-916'));
+    assert.equal(false, isPersonnummer('19900101-001'));
+    assert.equal(false, isPersonnummer('100101+001'));
 });
 
 it('should not validate wrong personnummer or wrong types', function () {
-  assert.equal(false, isPersonnummer(undefined));
-  assert.equal(false, isPersonnummer(null));
-  assert.equal(false, isPersonnummer([]));
-  assert.equal(false, isPersonnummer({}));
-  assert.equal(false, isPersonnummer(false));
-  assert.equal(false, isPersonnummer(true));
-  assert.equal(false, isPersonnummer(1122334455));
-  assert.equal(false, isPersonnummer('112233-4455'));
-  assert.equal(false, isPersonnummer('19112233-4455'));
-  assert.equal(false, isPersonnummer('9999999999'));
-  assert.equal(false, isPersonnummer('199999999999'));
-  assert.equal(false, isPersonnummer('9913131315'));
-  assert.equal(false, isPersonnummer('9911311232'));
-  assert.equal(false, isPersonnummer('9902291237'));
-  assert.equal(false, isPersonnummer('19990919_3766'));
-  assert.equal(false, isPersonnummer('990919_3766'));
-  assert.equal(false, isPersonnummer('199909193776'));
-  assert.equal(false, isPersonnummer('Just a string'));
-  assert.equal(false, isPersonnummer('990919+3776'));
-  assert.equal(false, isPersonnummer('990919-3776'));
-  assert.equal(false, isPersonnummer('9909193776'));
+    assert.equal(false, isPersonnummer(undefined));
+    assert.equal(false, isPersonnummer(null));
+    assert.equal(false, isPersonnummer([]));
+    assert.equal(false, isPersonnummer({}));
+    assert.equal(false, isPersonnummer(false));
+    assert.equal(false, isPersonnummer(true));
+    assert.equal(false, isPersonnummer(1122334455));
+    assert.equal(false, isPersonnummer('112233-4455'));
+    assert.equal(false, isPersonnummer('19112233-4455'));
+    assert.equal(false, isPersonnummer('9999999999'));
+    assert.equal(false, isPersonnummer('199999999999'));
+    assert.equal(false, isPersonnummer('9913131315'));
+    assert.equal(false, isPersonnummer('9911311232'));
+    assert.equal(false, isPersonnummer('9902291237'));
+    assert.equal(false, isPersonnummer('19990919_3766'));
+    assert.equal(false, isPersonnummer('990919_3766'));
+    assert.equal(false, isPersonnummer('199909193776'));
+    assert.equal(false, isPersonnummer('Just a string'));
+    assert.equal(false, isPersonnummer('990919+3776'));
+    assert.equal(false, isPersonnummer('990919-3776'));
+    assert.equal(false, isPersonnummer('9909193776'));
 });
 
 it('should validate co-ordination numbers', function () {
-  assert.equal(true, isPersonnummer('701063-2391'));
-  assert.equal(true, isPersonnummer('640883-3231'));
+    assert.equal(true, isPersonnummer('701063-2391'));
+    assert.equal(true, isPersonnummer('640883-3231'));
 });
 
 it('should not validate wrong co-ordination numbers', function () {
-  assert.equal(false, isPersonnummer('900161-0017'));
-  assert.equal(false, isPersonnummer('640893-3231'));
+    assert.equal(false, isPersonnummer('900161-0017'));
+    assert.equal(false, isPersonnummer('640893-3231'));
 });


### PR DESCRIPTION
These changes should fix #2 - it seemed to be an old issue caused by [minimist](https://github.com/substack/minimist), which in turn is used by meow. For some reason, it did not accept certain amounts of leading zeros as cli args, and simply did not include them at all.